### PR TITLE
Add has_message(...) Twig function

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,17 @@ $view->addExtension(new Knlv\Slim\Views\TwigMessages(
 ```
 
 - In templates use `flash()` or `flash('some_key')` to fetch messages from Flash service
+- Conditionally display flash messages using has_message('some_key')
 
 ``` html
 ...
-<ul class="alert alert-danger">
-    {% for msg in flash('error') %}
-    <li>{{ msg }}</li>
-    {% endfor %}
-</ul>
+{% if has_message('error') %}
+    <ul class="alert alert-danger">
+        {% for msg in flash('error') %}
+        <li>{{ msg }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}
 ...
 ```
 

--- a/src/TwigMessages.php
+++ b/src/TwigMessages.php
@@ -49,6 +49,7 @@ class TwigMessages extends Twig_Extension
     {
         return [
             new Twig_SimpleFunction('flash', [$this, 'getMessages']),
+            new Twig_SimpleFunction('has_message', [$this, 'hasMessage']),
         ];
     }
 
@@ -67,5 +68,17 @@ class TwigMessages extends Twig_Extension
         }
 
         return $this->flash->getMessages();
+    }
+
+    /**
+     * Checks for the existence of flash messages for a specific key
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function hasMessage($key)
+    {
+        return $this->flash->hasMessage($key);
     }
 }

--- a/tests/TwigMessagesTest.php
+++ b/tests/TwigMessagesTest.php
@@ -35,7 +35,8 @@ class TwigMessagesTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->setMethods(array(
               'getMessages',
-              'getMessage'
+              'getMessage',
+              'hasMessage',
             ))
             ->getMock();
         $this->flash->expects($this->any())
@@ -45,6 +46,11 @@ class TwigMessagesTest extends \PHPUnit_Framework_TestCase
             ->method('getMessage')
             ->will($this->returnCallback(function ($key) {
                 return isset($this->dummyMessages[$key]) ? $this->dummyMessages[$key] : null;
+            }));
+        $this->flash->expects($this->any())
+            ->method('hasMessage')
+            ->will($this->returnCallback(function ($key) {
+                return isset($this->dummyMessages[$key]);
             }));
 
         $this->extension = new TwigMessages($this->flash);
@@ -70,6 +76,20 @@ key1: another message
 key2: only one message
 
 EOF;
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testKeyDoesNotHaveMessages()
+    {
+        $result = $this->view->render('non-existent-key.twig');
+        $expected = ''; 
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testKeyDoesHaveMessages()
+    {
+        $result = $this->view->render('existent-key.twig');
+        $expected = 'This should display'; 
         $this->assertEquals($expected, $result);
     }
 }

--- a/tests/templates/existent-key.twig
+++ b/tests/templates/existent-key.twig
@@ -1,0 +1,1 @@
+{% if has_message('key1') %}This should display{% endif %}

--- a/tests/templates/non-existent-key.twig
+++ b/tests/templates/non-existent-key.twig
@@ -1,0 +1,1 @@
+{% if has_message('non-existant-tag') %}This should not display{% endif %}


### PR DESCRIPTION
Adds a has_message('key') twig function that exposes the base Flash hasMessage() function to test if a key has messages. Useful for selectively displaying template elements, like error divs.